### PR TITLE
Fix case, import in function body, Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,11 @@ in some drones. Parameter names are different between these two tools though.
 
 Example of asking Flight Controller for hardware and firmware version data (tested on Ph3):
 
-```./comm_serialtalk.py /dev/ttyUSB0 -vv --timeout=5000 --receiver_type=FlyController --seq_num=65280 --ack_type=No_ACK_Needed --cmd_set=General --cmd_id=1```
+```./comm_serialtalk.py -port /dev/ttyUSB0 -vv --timeout=5000 --receiver_type=FlyController --seq_num=65280 --ack_type=No_ACK_Needed --cmd_set=General --cmd_id=1```
+
+Example of asking Flight Controller for hardware and firmware version data (Mavic 3):
+
+```./comm_serialtalk.py -bulk -vv --timeout=5000 --receiver_type=FlyController --seq_num=65280 --ack_type=No_ACK_Needed --cmd_set=General --cmd_id=1```
 
 ### comm_og_service_tool.py
 
@@ -454,23 +458,27 @@ like `comm_serialtalk.py`, but provides easier interface for some important func
 
 Example of listing Flight Controller Parameters 200-300 on Ph3 Pro to CSV format:
 
-```./comm_og_service_tool.py /dev/ttyUSB0 P3X FlycParam list --start=200 --count=100 --fmt=csv```
+```./comm_og_service_tool.py -port /dev/ttyUSB0 P3X FlycParam list --start=200 --count=100 --fmt=csv```
 
 Example of getting value of Flight Controller Parameters on Spark:
 
-```./comm_og_service_tool.py /dev/ttyUSB0 -vv SPARK FlycParam get g_config.flying_limit.max_height_0 --fmt=2line```
+```./comm_og_service_tool.py -port /dev/ttyUSB0 -vv SPARK FlycParam get g_config.flying_limit.max_height_0 --fmt=2line```
 
 Example of setting value of Flight Controller Parameters on Spark:
 
-```./comm_og_service_tool.py /dev/ttyUSB0 -vv SPARK FlycParam set g_config.flying_limit.max_height_0 500```
+```./comm_og_service_tool.py -port /dev/ttyUSB0 -vv SPARK FlycParam set g_config.flying_limit.max_height_0 500```
 
 Example of performing service "joint coarse" calibration of Spark gimbal:
 
-```./comm_og_service_tool.py /dev/ttyUSB0 -vv SPARK GimbalCalib JointCoarse```
+```./comm_og_service_tool.py -port /dev/ttyUSB0 -vv SPARK GimbalCalib JointCoarse```
 
 Example of performing service "linear hall" calibration of Spark gimbal, using Windows host:
 
-```python3 comm_og_service_tool.py COM23 -vv SPARK GimbalCalib LinearHall```
+```python3 comm_og_service_tool.py -port COM23 -vv SPARK GimbalCalib LinearHall```
+
+Example of listing Flight Controller Parameters 200-300 on the Mavic 3 Pro to CSV format:
+
+```./comm_og_service_tool.py -bulk MAV3 FlycParam list --start=200 --count=100 --fmt=csv```
 
 ### comm_sbs_bqctrl.py
 

--- a/README.md
+++ b/README.md
@@ -443,11 +443,11 @@ in some drones. Parameter names are different between these two tools though.
 
 Example of asking Flight Controller for hardware and firmware version data (tested on Ph3):
 
-```./comm_serialtalk.py -port /dev/ttyUSB0 -vv --timeout=5000 --receiver_type=FlyController --seq_num=65280 --ack_type=No_ACK_Needed --cmd_set=General --cmd_id=1```
+```./comm_serialtalk.py --port /dev/ttyUSB0 -vv --timeout=5000 --receiver_type=FlyController --seq_num=65280 --ack_type=No_ACK_Needed --cmd_set=General --cmd_id=1```
 
 Example of asking Flight Controller for hardware and firmware version data (Mavic 3):
 
-```./comm_serialtalk.py -bulk -vv --timeout=5000 --receiver_type=FlyController --seq_num=65280 --ack_type=ACK_After_Exec --cmd_set=General --cmd_id=1```
+```./comm_serialtalk.py --bulk -vv --timeout=5000 --receiver_type=FlyController --seq_num=65280 --ack_type=ACK_After_Exec --cmd_set=General --cmd_id=1```
 
 ### comm_og_service_tool.py
 
@@ -458,27 +458,27 @@ like `comm_serialtalk.py`, but provides easier interface for some important func
 
 Example of listing Flight Controller Parameters 200-300 on Ph3 Pro to CSV format:
 
-```./comm_og_service_tool.py -port /dev/ttyUSB0 P3X FlycParam list --start=200 --count=100 --fmt=csv```
+```./comm_og_service_tool.py --port /dev/ttyUSB0 P3X FlycParam list --start=200 --count=100 --fmt=csv```
 
 Example of getting value of Flight Controller Parameters on Spark:
 
-```./comm_og_service_tool.py -port /dev/ttyUSB0 -vv SPARK FlycParam get g_config.flying_limit.max_height_0 --fmt=2line```
+```./comm_og_service_tool.py --port /dev/ttyUSB0 -vv SPARK FlycParam get g_config.flying_limit.max_height_0 --fmt=2line```
 
 Example of setting value of Flight Controller Parameters on Spark:
 
-```./comm_og_service_tool.py -port /dev/ttyUSB0 -vv SPARK FlycParam set g_config.flying_limit.max_height_0 500```
+```./comm_og_service_tool.py --port /dev/ttyUSB0 -vv SPARK FlycParam set g_config.flying_limit.max_height_0 500```
 
 Example of performing service "joint coarse" calibration of Spark gimbal:
 
-```./comm_og_service_tool.py -port /dev/ttyUSB0 -vv SPARK GimbalCalib JointCoarse```
+```./comm_og_service_tool.py --port /dev/ttyUSB0 -vv SPARK GimbalCalib JointCoarse```
 
 Example of performing service "linear hall" calibration of Spark gimbal, using Windows host:
 
-```python3 comm_og_service_tool.py -port COM23 -vv SPARK GimbalCalib LinearHall```
+```python3 comm_og_service_tool.py --port COM23 -vv SPARK GimbalCalib LinearHall```
 
 Example of listing Flight Controller Parameters 200-300 on the Mavic 3 Pro to CSV format:
 
-```./comm_og_service_tool.py -bulk MAV3 FlycParam list --start=200 --count=100 --fmt=csv```
+```./comm_og_service_tool.py --bulk MAV3 FlycParam list --start=200 --count=100 --fmt=csv```
 
 ### comm_sbs_bqctrl.py
 

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Example of asking Flight Controller for hardware and firmware version data (test
 
 Example of asking Flight Controller for hardware and firmware version data (Mavic 3):
 
-```./comm_serialtalk.py -bulk -vv --timeout=5000 --receiver_type=FlyController --seq_num=65280 --ack_type=No_ACK_Needed --cmd_set=General --cmd_id=1```
+```./comm_serialtalk.py -bulk -vv --timeout=5000 --receiver_type=FlyController --seq_num=65280 --ack_type=ACK_After_Exec --cmd_set=General --cmd_id=1```
 
 ### comm_og_service_tool.py
 

--- a/comm_og_service_tool.py
+++ b/comm_og_service_tool.py
@@ -32,7 +32,6 @@ import time
 import enum
 import types
 import struct
-import serial
 import select
 import hashlib
 import binascii
@@ -41,7 +40,7 @@ from ctypes import *
 
 sys.path.insert(0, './')
 from comm_serialtalk import (
-  do_send_request, do_receive_reply, SerialMock, openUsb
+  do_send_request, do_receive_reply, SerialMock, open_usb
 )
 from comm_mkdupc import *
 
@@ -147,9 +146,10 @@ def detect_serial_port(po):
 def open_serial_port(po):
     ser = None
     if po.bulk:
-        ser = openUsb(po)
+        ser = open_usb(po)
     else:
         # Open serial port
+        import serial
         if po.port == 'auto':
             port_name = detect_serial_port(po)
         else:

--- a/comm_og_service_tool.py
+++ b/comm_og_service_tool.py
@@ -1525,12 +1525,12 @@ def main():
     """
     parser = argparse.ArgumentParser(description=__doc__)
 
-    subparser = parser.add_mutually_exclusive_group()
+    subparser = parser.add_mutually_exclusive_group(required=True)
 
-    subparser.add_argument('-port', type=str,
+    subparser.add_argument('--port', type=str,
             help='the serial port to write to and read from')
 
-    subparser.add_argument('-bulk', action='store_true',
+    subparser.add_argument('--bulk', action='store_true',
             help='use usb bulk instead of serial connection')
 
     parser.add_argument('product', metavar='product', choices=[i.name for i in PRODUCT_CODE], type=parse_product_code,
@@ -1629,10 +1629,6 @@ def main():
              "lead to inconsistent keys due to their read-only copy")
 
     po = parser.parse_args()
-
-    if (po.bulk is False and po.port is None):
-        print('Atleast one argument "-bulk" or "-port" is needed!')
-        sys.exit(0)
 
     po.product = PRODUCT_CODE.from_name(po.product)
     po.svcmd = SERVICE_CMD.from_name(po.svcmd)

--- a/comm_serialtalk.py
+++ b/comm_serialtalk.py
@@ -326,12 +326,12 @@ def main():
     """
     parser = argparse.ArgumentParser(description=__doc__)
 
-    subparser = parser.add_mutually_exclusive_group()
+    subparser = parser.add_mutually_exclusive_group(required=True)
 
-    subparser.add_argument('-port', type=str,
+    subparser.add_argument('--port', type=str,
             help='the serial port to write to and read from')
 
-    subparser.add_argument('-bulk', action='store_true',
+    subparser.add_argument('--bulk', action='store_true',
             help='use usb bulk instead of serial connection')
 
     parser.add_argument('-b', '--baudrate', default=9600, type=int,
@@ -399,10 +399,6 @@ def main():
             help='provide binary payload directly (default payload is empty)')
 
     po = parser.parse_args();
-
-    if (po.bulk is False and po.port is None):
-        print('Atleast one argument "-bulk" or "-port" is needed!')
-        sys.exit(0)
 
     if (po.payload_hex is not None):
         po.payload = bytes.fromhex(po.payload_hex)


### PR DESCRIPTION
This should fix the wrong case, also it includes the imports of serial or usb inside the function body, this should help to not enforce all dependencies for all users. Also i updated the Readme to reflect the usage of the -port or -bulk for the service and the serialtalk tool.
Feel free to reject or comment if something is missing. I tested the scripts with Air2s and Mav3, both work fine.