### PR TITLE
cfg of usb needs to be different on windows and linux

### DIFF
--- a/comm_serialtalk.py
+++ b/comm_serialtalk.py
@@ -154,7 +154,12 @@ def open_usb(po):
 
     if dev:
         cfg = dev.get_active_configuration()
-        intf = cfg[(0,0)]
+        
+        if sys.platform in ('win32', 'win64'):
+            intf = cfg[(0,0)]
+        else:
+            intf = cfg[(4,0)]
+            
 
         ep_out = usb.util.find_descriptor(
             intf,


### PR DESCRIPTION
The windows driver behaves strange in comparison to the linux driver. This approach uses a OS depended cfg and should work on all platforms properly now. 