### PR TITLE
Added support for DJI Ronin to Bluetooth dissector

### DIFF
--- a/comm_dissector/wireshark/dji-dumlv1-proto.lua
+++ b/comm_dissector/wireshark/dji-dumlv1-proto.lua
@@ -3288,8 +3288,10 @@ end
 function DJI_DUMLv1_PROTO.init ()
     -- Non-heuristic USB dissector registration would look like this
     --DissectorTable.get("usb.bulk"):add(0xffff, DJI_DUMLv1_PROTO)
-    -- Bluetooth dissector, used for DJI Osmo devices
-    DissectorTable.get("btatt.handle"):add(0x0018, DJI_DUMLv1_PROTO)
+    -- Bluetooth dissector, used for DJI Osmo and Ronin devices
+    DissectorTable.get("btatt.handle"):add(0x0018, DJI_DUMLv1_PROTO) -- Osmo
+    DissectorTable.get("btatt.handle"):add(0x0010, DJI_DUMLv1_PROTO) -- Ronin (value notification)
+    DissectorTable.get("btatt.handle"):add(0x0013, DJI_DUMLv1_PROTO) -- Ronin (write)
 end
 
 DJI_DUMLv1_PROTO:register_heuristic("usb.bulk", heuristic_dissector)


### PR DESCRIPTION
The DJI Ronin SC (and probably other Ronin devices too) use the same packet structure and Bluetooth protocol as the Osmo series, but with the handles `0x10` (for opcode `0x1b`) and `0x13` (for opcode `0x52`). 

<details>
<summary>Screenshots: </summary>

![image](https://user-images.githubusercontent.com/3891092/147979352-4958f432-81af-494c-8c6c-d07c53528922.png) ![image](https://user-images.githubusercontent.com/3891092/147980191-126f15bf-0136-4cca-ba7b-87e7c63ed28e.png)

</details>

*(thanks for all the great work btw, it's been a great resource for reverse-engineering my gimbal!)*