### PR TITLE
comm_serialtalk: dispose usb resource in SerialBulkWrap.close() 

### DIFF
--- a/comm_serialtalk.py
+++ b/comm_serialtalk.py
@@ -123,7 +123,8 @@ class SerialBulkWrap():
         return btarr
 
     def close(self):
-        pass
+        import usb.util
+        usb.util.dispose_resources(self.dev)
 
     def reset_input_buffer(self):
         pass


### PR DESCRIPTION
This adds implementation for close() method of SerialBulkWrap class by disposing the acquired usb resource.  

It  prevents the following error if one tries to reuse comm_serialtalk within an application:
usb.core.USBError: [Errno None] b'libusb0-dll:err [claim_interface] could not claim interface 4, win error: The requested resource is in use.